### PR TITLE
Reimplement in Python

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS= -I m4
 SUBDIRS = po
 
 EXTRA_DIST = \
-        sshpwd.sh \
+        sshpwd.py \
         pprompt.desktop
 
 install-data-local:

--- a/configure.ac
+++ b/configure.ac
@@ -9,131 +9,22 @@ AC_CONFIG_MACRO_DIR([m4])
 # to configure or passing V=1 to make
 AM_SILENT_RULES([yes])
 
-# Force to dynamic
-AC_DISABLE_STATIC
-
 # Checks for programs.
-AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_LN_S
 IT_PROG_INTLTOOL([0.40.0], [no-xml])
 AM_PROG_CC_C_O
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
-#Initialize libtool
-LT_PREREQ([2.2])
-LT_INIT
-
 # Checks for libraries.
-pkg_modules="$pkg_modules gtk+-2.0 >= 2.18.0"
+pkg_modules="$pkg_modules gtk+-3.0 >= 3.10.0"
 
 PKG_CHECK_MODULES(PACKAGE, [$pkg_modules])
 AC_SUBST(PACKAGE_CFLAGS)
 AC_SUBST(PACKAGE_LIBS)
 
-pkg_modules="x11"
-PKG_CHECK_MODULES(X11, [$pkg_modules])
-AC_SUBST(X11_LIBS)
-
-AC_ARG_ENABLE(more_warnings,
-       [AC_HELP_STRING([--enable-more-warnings],
-               [Add more warnings @<:@default=no@:>@])],
-       [enable_more_warnings="${enableval}"],
-       [enable_more_warnings=no]
-)
-
-if test x"$enable_more_warnings" = x"yes"; then
-  ADDITIONAL_FLAGS="-Wall -Werror=all -Werror=format -Werror=implicit-function-declaration -Werror=implicit-int -Werror=missing-braces -Werror=parentheses -Werror=return-type -Werror=strict-aliasing -Werror=switch -Wuninitialized -Werror=unused-label -Werror=unused-value -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Werror=missing-declarations -Wredundant-decls -Wmissing-noreturn -Wpointer-arith -Wcast-align -Wwrite-strings -Werror=inline -Werror=format-nonliteral -Wformat-nonliteral -Werror=format-security -Wformat-security -Winit-self -Werror=missing-include-dirs -Werror=undef -Werror=aggregate-return -Wmissing-format-attribute -Werror=nested-externs -fno-strict-aliasing -fmessage-length=0 -Wp,-D_FORTIFY_SOURCE=2 -DG_DISABLE_DEPRECATED -DG_DISABLE_SINGLE_INCLUDES -DGDK_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_SINGLE_INCLUDES -DGTK_DISABLE_DEPRECATED -DGTK_DISABLE_SINGLE_INCLUDES"
-fi
-AC_SUBST(ADDITIONAL_FLAGS)
-
 PACKAGE_CFLAGS="$PACKAGE_CFLAGS $ADDITIONAL_FLAGS"
 PACKAGE_LIBS="$PACKAGE_LIBS"
-
-dnl linker tweaking
-# The function of the link flag --as-needed is to prevent unnecesary linking.
-# Example: A -> B -> C
-# Normally, A would link to B and also depend on C, this is of cource
-# unnecesary. In this situation, however we do need to link to C, so this
-# must be done explicitly. This flag comes in handy when a library ABI
-# is changed, minimizing the amount of recompilations needed.
-AC_MSG_CHECKING([whether $LD accepts --as-needed])
-case `$LD --as-needed -v 2>&1 </dev/null` in
-*GNU* | *'with BFD'*)
-    LDFLAGS="$LDFLAGS -Wl,--as-needed"
-    AC_MSG_RESULT([yes])
-    ;;
-*)
-    AC_MSG_RESULT([no])
-    ;;
-esac
-
-dnl linker optimizations
-AC_MSG_CHECKING([whether $LD accepts -O1])
-case `$LD -O1 -v 2>&1 </dev/null` in
-*GNU* | *'with BFD'*)
-  LDFLAGS="$LDFLAGS -Wl,-O1"
-  AC_MSG_RESULT([yes])
-  ;;
-*)
-  AC_MSG_RESULT([no])
-  ;;
-esac
-AC_MSG_CHECKING([whether $LD accepts -Bsymbolic-functions])
-case `$LD -Bsymbolic-functions -v 2>&1 </dev/null` in
-*GNU* | *'with BFD'*)
-  LDFLAGS="$LDFLAGS -Wl,-Bsymbolic-functions"
-  AC_MSG_RESULT([yes])
-  ;;
-*)
-  AC_MSG_RESULT([no])
-  ;;
-esac
-AC_MSG_CHECKING([whether $LD accepts --sort-common])
-case `$LD --sort-common -v 2>&1 </dev/null` in
-*GNU* | *'with BFD'*)
-  LDFLAGS="$LDFLAGS -Wl,--sort-common"
-  AC_MSG_RESULT([yes])
-  ;;
-*)
-  AC_MSG_RESULT([no])
-  ;;
-esac
-
-dnl FIXME: filter for undefined symbols in plugins
-# when passing "-z defs" to linker, we would better to make sure
-# there are no undefined references.  However, we intend not to
-# fix at the moment since we don't have spin-off libraray containing
-# the necessary functions.
-if test ! -z "$LDFLAGS"; then
-    LDFLAGS=`echo "$LDFLAGS" | sed -e 's/-Wl,-z,defs//'`
-fi
-
-# Checks for header files.
-AC_PATH_X
-AC_HEADER_STDC
-AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS([locale.h stdlib.h string.h sys/time.h unistd.h])
-
-# Checks for typedefs, structures, and compiler characteristics.
-AC_C_CONST
-AC_C_INLINE
-AC_STRUCT_TM
-
-# Checks for library functions.
-AC_FUNC_MALLOC
-AC_FUNC_MEMCMP
-AC_TYPE_SIGNAL
-AC_FUNC_STAT
-AC_FUNC_STRFTIME
-AC_CHECK_FUNCS([bzero memset mkdir setlocale strchr])
-
-dnl check for menu-cache versions 0.4.x since no macro MENU_CACHE_CHECK_VERSION
-dnl is available in those versions
-LIBS_save="${LIBS}"
-LIBS="${LIBS} ${MENU_CACHE_LIBS}"
-AC_CHECK_FUNCS(menu_cache_dir_list_children)
-LIBS="${LIBS_save}"
 
 # Generate po/LINGUAS on the fly rather than relying on translators
 # to maintain it manually. This also overcome the problem that Transifex
@@ -150,29 +41,6 @@ AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Gettext package.])
 
 AM_GLIB_GNU_GETTEXT
-
-AC_ARG_ENABLE(debug,
-    [AC_HELP_STRING([--enable-debug],
-        [enable debug support @<:@default=no@:>@])],
-    [enable_debug="${enableval}"],
-    [enable_debug=no]
-)
-if test "$enable_debug" = "yes"; then
-    # turn on debug and disable optimization
-    CPPFLAGS="$CPPFLAGS -DG_ENABLE_DEBUG -O0 -g"
-    case "$CC" in
-    gcc*)
-        CPPFLAGS="$CPPFLAGS -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration"
-        ;;
-    *)
-        ;;
-    esac
-    dnl Be more strict on portability
-    #CPPFLAGS="$CPPFLAGS -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=700"
-else
-    # turn off glib debug checks
-    CPPFLAGS="$CPPFLAGS -DG_DISABLE_ASSERT -DG_DISABLE_CHECKS -DG_DISABLE_CAST_CHECKS"
-fi
 
 dnl Fix invalid sysconfdir when --prefix=/usr
 if test `eval "echo $sysconfdir"` = /usr/etc
@@ -198,5 +66,3 @@ if test x"$sysconfdir" != x'/etc'; then
     echo 'Warning: sysconfdir is not /etc. It might be not what you want.'
     echo 'Please consider passing --sysconfdir=/etc to configure.'
 fi
-
-

--- a/debian/pprompt.install
+++ b/debian/pprompt.install
@@ -1,2 +1,2 @@
-sshpwd.sh etc/xdg/lxsession/LXDE-pi/
+sshpwd.py etc/xdg/lxsession/LXDE-pi/
 pprompt.desktop etc/xdg/autostart/

--- a/po/Makefile.in.in
+++ b/po/Makefile.in.in
@@ -33,8 +33,7 @@ exec_prefix = @exec_prefix@
 datadir = @datadir@
 datarootdir = @datarootdir@
 libdir = @libdir@
-DATADIRNAME = @DATADIRNAME@
-itlocaledir = $(prefix)/$(DATADIRNAME)/locale
+localedir = @localedir@
 subdir = po
 install_sh = @install_sh@
 # Automake >= 1.8 provides @mkdir_p@.
@@ -80,7 +79,7 @@ INTLTOOL__v_MSGFMT_0 = @echo "  MSGFMT" $@;
 
 .po.pox:
 	$(MAKE) $(GETTEXT_PACKAGE).pot
-	$(MSGMERGE) $< $(GETTEXT_PACKAGE).pot -o $*.pox
+	$(MSGMERGE) $* $(GETTEXT_PACKAGE).pot -o $*.pox
 
 .po.mo:
 	$(INTLTOOL_V_MSGFMT)$(MSGFMT) -o $@ $<
@@ -108,7 +107,7 @@ install-data-no: all
 install-data-yes: all
 	linguas="$(USE_LINGUAS)"; \
 	for lang in $$linguas; do \
-	  dir=$(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES; \
+	  dir=$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES; \
 	  $(mkdir_p) $$dir; \
 	  if test -r $$lang.gmo; then \
 	    $(INSTALL_DATA) $$lang.gmo $$dir/$(GETTEXT_PACKAGE).mo; \
@@ -142,8 +141,8 @@ install-exec installcheck:
 uninstall:
 	linguas="$(USE_LINGUAS)"; \
 	for lang in $$linguas; do \
-	  rm -f $(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
-	  rm -f $(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo.m; \
+	  rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
+	  rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo.m; \
 	done
 
 check: all $(GETTEXT_PACKAGE).pot

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,1 +1,1 @@
-sshpwd.sh
+sshpwd.py

--- a/po/pprompt.pot
+++ b/po/pprompt.pot
@@ -1,21 +1,21 @@
-# English translations for pprompt package.
-# Copyright (C) 2017 Raspberry Pi
-# This file is distributed under the same license as the pprompt package.
-#  <simon@raspberrypi.org>, 2017.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-10 20:27+0100\n"
-"PO-Revision-Date: 2017-01-24 10:54+0000\n"
-"Last-Translator:  <simon@raspberrypi.org>\n"
-"Language-Team: English (British)\n"
-"Language: en_GB\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Error message when rc_gui failed to start
 #: ../sshpwd.py:49

--- a/pprompt.desktop
+++ b/pprompt.desktop
@@ -3,5 +3,5 @@ Type=Application
 Name=pprompt
 Comment=Prompt to change default password if ssh enabled
 NoDisplay=true
-Exec=sh /etc/xdg/lxsession/LXDE-pi/sshpwd.sh
+Exec=python3 /etc/xdg/lxsession/LXDE-pi/sshpwd.py
 NotShowIn=GNOME;KDE;XFCE;

--- a/sshpwd.py
+++ b/sshpwd.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+# If the flag doesn't exist
+if not Path("/run/sshwarn").exists():
+    # Exit early
+    raise SystemExit
+
+# Init gettext
+from gettext import gettext, bindtextdomain
+bindtextdomain('pprompt')
+
+# Load Gtk
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gdk, Gio, GLib
+
+from getpass import getuser
+
+
+# Callback for clicked link
+def activate(label, uri, dlg):
+    # We only handle links to 'config', let Gtk handle anything else
+    if uri != 'config':
+        return False
+
+    # We are launching 'rc_gui'
+    app = Gio.AppInfo.create_from_commandline('rc_gui', None, 0)
+    # On the current display
+    screen = label.get_screen()
+    if screen:
+        display = screen.get_display()
+    else:
+        display = Gdk.Display.get_default()
+    ctx = display.get_app_launch_context()
+    if screen:
+        ctx.set_screen(screen)
+
+    try:
+        # Start the program
+        app.launch([], ctx)
+
+        # Close the dialog
+        def close():
+            dlg.destroy()
+            return GLib.SOURCE_REMOVE
+        GLib.idle_add(close)
+    except:
+        # Error message when rc_gui failed to start
+        msg = gettext('Failed to start Raspberry Pi Configuration')
+        # Modal error dialog
+        err = Gtk.MessageDialog(dlg,
+                                Gtk.DialogFlags.MODAL,
+                                Gtk.MessageType.ERROR,
+                                Gtk.ButtonsType.CLOSE,
+                                msg)
+        # Close when button pressed
+        err.connect("response", lambda d, r: d.destroy())
+        # Close parent with this one
+        err.connect("destroy", lambda d: dlg.destroy())
+        # Show this dialog
+        err.show()
+    # We handled the link
+    return True
+
+
+# Dialog title
+title = gettext('Change Password')
+# Main message
+msg = gettext('SSH is enabled and the default password for the \'pi\' user '
+              'has not been changed')
+# Check the current user
+if getuser() == 'pi':
+    # They are pi, include link to open rc_gui
+    info = gettext('This is a <b>security risk</b>, please run '
+                   '<a href="config">Raspberry Pi Configuration</a> '
+                   'to set a new password.')
+else:
+    # They aren't pi, tell them to switch to pi and run rc_gui
+    info = gettext('This is a <b>security risk</b>, please login as the '
+                   '\'pi\' user and run Raspberry Pi Configuration to set a '
+                   'new password.')
+
+
+# Setup the dialog, we don't have a parent so a warning will be logged
+# It's a warning with a [Close] button, pango text & 400 wide
+dlg = Gtk.MessageDialog(message_type=Gtk.MessageType.WARNING,
+                        buttons=Gtk.ButtonsType.CLOSE,
+                        text=title,
+                        secondary_text="{}\n\n{}".format(msg, info),
+                        secondary_use_markup=True,
+                        width_request=400)
+# When closed quit the program
+dlg.connect("destroy", Gtk.main_quit)
+# When a button is clicked close the dialog
+dlg.connect("response", lambda d, r: d.destroy())
+
+
+def connect_activate(lbl):
+    lbl.connect('activate-link', activate, dlg)
+
+
+# Connect to activate-link on the label
+dlg.get_message_area().foreach(connect_activate)
+
+# Show the dialog
+dlg.show()
+# Start the mainloop
+Gtk.main()

--- a/sshpwd.sh
+++ b/sshpwd.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-export TEXTDOMAIN=pprompt
-
-. gettext.sh
-
-if [ -e /run/sshwarn ] ; then
-	zenity --warning --width=400 --text="$(gettext "SSH is enabled and the default password for the 'pi' user has not been changed.\n\nThis is a security risk - please login as the 'pi' user and run Raspberry Pi Configuration to set a new password.")"
-fi


### PR DESCRIPTION
I'm sure your aware of the current zenity dialog: 
![2018-09-10-201113_1392x868_scrot](https://user-images.githubusercontent.com/17074021/45322184-71b42a80-b53f-11e8-92ab-d31e76de36e1.png)

This PR reimplements the dialog in Python 3 with some extra functionality, when the current user is *not* `pi` the current wording is retained. However when running as `pi` the wording is shortened and 'Raspberry Pi Configuration' is a link that launches `rc_gui` and dismisses the dialog
![2018-09-10-201348_1392x868_scrot](https://user-images.githubusercontent.com/17074021/45322188-74168480-b53f-11e8-8d70-e2a46c936d65.png)
